### PR TITLE
Strings py2

### DIFF
--- a/compiler/cpp/src/generate/t_py_generator.cc
+++ b/compiler/cpp/src/generate/t_py_generator.cc
@@ -59,6 +59,12 @@ public:
     iter = parsed_options.find("slots");
     gen_slots_ = (iter != parsed_options.end());
 
+    iter = parsed_options.find("package_prefix");
+    if (iter != parsed_options.end()) {
+      package_prefix_ = iter->second;
+    }
+
+
     iter = parsed_options.find("dynamic");
     gen_dynamic_ = (iter != parsed_options.end());
 
@@ -233,7 +239,7 @@ public:
     return sub_namespace == "twisted";
   }
 
-  static std::string get_real_py_module(const t_program* program, bool gen_twisted) {
+  static std::string get_real_py_module(const t_program* program, bool gen_twisted, std::string package_dir="") {
     if (gen_twisted) {
       std::string twisted_module = program->get_namespace("py.twisted");
       if (!twisted_module.empty()) {
@@ -245,7 +251,7 @@ public:
     if (real_module.empty()) {
       return program->get_name();
     }
-    return real_module;
+    return package_dir + real_module;
   }
 
   static bool is_immutable(t_type* ttype) {
@@ -295,6 +301,8 @@ private:
    * eg. # -*- coding: utf-8 -*-
    */
   string coding_;
+
+  string package_prefix_;
 
   /**
    * File streams
@@ -378,7 +386,7 @@ string t_py_generator::render_includes() {
   const vector<t_program*>& includes = program_->get_includes();
   string result = "";
   for (size_t i = 0; i < includes.size(); ++i) {
-    result += "import " + get_real_py_module(includes[i], gen_twisted_) + ".ttypes\n";
+    result += "import " + get_real_py_module(includes[i], gen_twisted_, package_prefix_) + ".ttypes\n";
   }
   return result;
 }
@@ -1036,7 +1044,7 @@ void t_py_generator::generate_service(t_service* tservice) {
 
   if (tservice->get_extends() != NULL) {
     f_service_ << "import "
-               << get_real_py_module(tservice->get_extends()->get_program(), gen_twisted_) << "."
+               << get_real_py_module(tservice->get_extends()->get_program(), gen_twisted_, package_prefix_) << "."
                << tservice->get_extends()->get_name() << endl;
   }
 
@@ -2489,10 +2497,10 @@ string t_py_generator::type_name(t_type* ttype) {
 
   t_program* program = ttype->get_program();
   if (ttype->is_service()) {
-    return get_real_py_module(program, gen_twisted_) + "." + ttype->get_name();
+    return get_real_py_module(program, gen_twisted_, package_prefix_) + "." + ttype->get_name();
   }
   if (program != NULL && program != program_) {
-    return get_real_py_module(program, gen_twisted_) + ".ttypes." + ttype->get_name();
+    return get_real_py_module(program, gen_twisted_, package_prefix_) + ".ttypes." + ttype->get_name();
   }
   return ttype->get_name();
 }
@@ -2585,4 +2593,6 @@ THRIFT_REGISTER_GENERATOR(
     "    dynfrozen=CLS    Derive generated immutable classes from class CLS instead of TFrozenBase.\n"
     "    dynexc=CLS       Derive generated exceptions from CLS instead of TExceptionBase.\n"
     "    dynimport='from foo.bar import CLS'\n"
-    "                     Add an import line to generated code to find the dynbase class.\n")
+    "                     Add an import line to generated code to find the dynbase class.\n"
+    "    package_prefix='top.package.'\n"
+    "                     Package prefix for generated files.\n")

--- a/lib/py/src/compat.py
+++ b/lib/py/src/compat.py
@@ -1,14 +1,21 @@
 import sys
+import logging
 
 if sys.version_info[0] == 2:
 
   from cStringIO import StringIO as BufferIO
 
   def binary_to_str(bin_val):
-    return bin_val
+    try:
+      return bin_val.decode('utf8')
+    except:
+      return bin_val
 
   def str_to_binary(str_val):
-    return str_val
+    try:
+      return str_val.encode('utf8')
+    except:
+      return str_val
 
 else:
 

--- a/lib/py/src/compat.py
+++ b/lib/py/src/compat.py
@@ -5,13 +5,19 @@ if sys.version_info[0] == 2:
 
   from cStringIO import StringIO as BufferIO
 
-  def binary_to_str(bin_val):
+  def binary_to_string(bin_val):
+    """
+    Change a binary value string b'' to a u''.
+    """
     try:
       return bin_val.decode('utf8')
     except:
       return bin_val
 
-  def str_to_binary(str_val):
+  def string_to_binary(str_val):
+    """
+    Change a string to binary, u'' to b''
+    """
     try:
       return str_val.encode('utf8')
     except:
@@ -21,13 +27,19 @@ else:
 
   from io import BytesIO as BufferIO
 
-  def binary_to_str(bin_val):
+  def binary_to_string(bin_val):
+    """
+    Change a binary value to a string, b'' to ''.
+    """
     try:
       return bin_val.decode('utf8')
     except:
       return bin_val
 
-  def str_to_binary(str_val):
+  def string_to_binary(str_val):
+    """
+    Change a string to binary, '' to b''
+    """
     try:
       return bytearray(str_val, 'utf8')
     except:

--- a/lib/py/src/protocol/TCompactProtocol.py
+++ b/lib/py/src/protocol/TCompactProtocol.py
@@ -20,7 +20,8 @@
 from .TProtocol import TType, TProtocolBase, TProtocolException, checkIntegerLimits
 from struct import pack, unpack
 
-from ..compat import binary_to_str, str_to_binary
+from ..compat import binary_to_string
+from ..compat import string_to_binary
 
 __all__ = ['TCompactProtocol', 'TCompactProtocolFactory']
 
@@ -143,7 +144,7 @@ class TCompactProtocol(TProtocolBase):
     self.__writeUByte(self.PROTOCOL_ID)
     self.__writeUByte(self.VERSION | (type << self.TYPE_SHIFT_AMOUNT))
     self.__writeVarint(seqid)
-    self.__writeBinary(str_to_binary(name))
+    self.__writeBinary(string_to_binary(name))
     self.state = VALUE_WRITE
 
   def writeMessageEnd(self):
@@ -320,7 +321,7 @@ class TCompactProtocol(TProtocolBase):
       raise TProtocolException(TProtocolException.BAD_VERSION,
                                'Bad version: %d (expect %d)' % (version, self.VERSION))
     seqid = self.__readVarint()
-    name = binary_to_str(self.__readBinary())
+    name = binary_to_string(self.__readBinary())
     return (name, type, seqid)
 
   def readMessageEnd(self):

--- a/lib/py/src/protocol/TJSONProtocol.py
+++ b/lib/py/src/protocol/TJSONProtocol.py
@@ -22,8 +22,8 @@ import base64
 import math
 import sys
 
-from ..compat import str_to_binary
-from ..compat import binary_to_str
+from ..compat import binary_to_string
+from ..compat import string_to_binary
 
 
 __all__ = ['TJSONProtocol',
@@ -212,7 +212,7 @@ class TJSONProtocolBase(TProtocolBase):
       escaped = ESCAPE_CHAR_VALS.get(s, s)
       json_str.append(escaped)
     json_str.append(QUOTE_CHAR)
-    self.trans.write(str_to_binary(EMPTY_STRING.join(json_str)))
+    self.trans.write(string_to_binary(EMPTY_STRING.join(json_str)))
 
   def writeJSONNumber(self, number, formatter='{}'):
     self.context.write()
@@ -331,7 +331,7 @@ class TJSONProtocolBase(TProtocolBase):
     # A JSON String must be decoded to the most String like type a language
     #  has, which is unicode in Python 2 and str in python 3.
     if PY2:
-      return binary_to_str(''.join(string))
+      return binary_to_string(''.join(string))
     return EMPTY_STRING.join(string)
 
   def isJSONNumeric(self, character):

--- a/lib/py/src/protocol/TProtocol.py
+++ b/lib/py/src/protocol/TProtocol.py
@@ -20,7 +20,8 @@
 from thrift.Thrift import TException, TType, TFrozenDict
 import six
 
-from ..compat import binary_to_str, str_to_binary
+from ..compat import binary_to_string
+from ..compat import string_to_binary
 
 
 class TProtocolException(TException):
@@ -103,7 +104,7 @@ class TProtocolBase:
     pass
 
   def writeString(self, str_val):
-    self.writeBinary(str_to_binary(str_val))
+    self.writeBinary(string_to_binary(str_val))
 
   def writeBinary(self, str_val):
     pass
@@ -163,7 +164,7 @@ class TProtocolBase:
     pass
 
   def readString(self):
-    return binary_to_str(self.readBinary())
+    return binary_to_string(self.readBinary())
 
   def readBinary(self):
     pass

--- a/lib/py/test/thrift_json.py
+++ b/lib/py/test/thrift_json.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from thrift import Thrift
 from thrift.protocol.TJSONProtocol import TJSONProtocol
 from thrift.transport import TTransport
@@ -22,8 +23,6 @@ class TestJSONString(unittest.TestCase):
     transport = TTransport.TBufferedTransportFactory().getTransport(buf)
     protocol = TJSONProtocol(transport)
 
-    if sys.version_info[0] == 2:
-      unicode_text = unicode_text.encode('utf8')
     self.assertEqual(protocol.readString(), unicode_text)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make thrift for Python 2 conceptually the same as Python 3, assigning String to unicode in Py2 and str in Py3.

@ericklaus-wf @tannermiller-wf
